### PR TITLE
fix: force js-yaml ^4.2.0 via overrides to resolve DoS advisory (#114)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,15 +1104,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1124,19 +1115,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -4347,19 +4325,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -10821,12 +10786,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "superagent": {
       "formidable": "^3.2.4"
     },
-    "tar": "^7.5.7"
+    "tar": "^7.5.7",
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
Adds `"js-yaml": "^4.2.0"` to the `overrides` block, forcing a single patched js-yaml across the whole dependency tree.

## Why
Dependabot alert #114 (GHSA-h67p-54hq-rp68): JS-YAML quadratic-complexity DoS in merge-key handling, vulnerable in `<=4.1.1`. The tree previously carried:
- `js-yaml@3.14.2` under `@istanbuljs/load-nyc-config` (coverage instrumentation)
- `js-yaml@4.1.1` under `@eslint/eslintrc`

npm's only offered fix was `audit fix --force` (downgrades Jest 29 → 25, breaking). The override forces both consumers onto the patched `4.2.0` instead.

## Safety
- `@istanbuljs/load-nyc-config` only calls `require('js-yaml').load()`, which exists in 4.x — no API break.
- `@eslint/eslintrc` already requires `^4.1.1`, so 4.2.0 satisfies it natively.

## Verification
- `npm run test:unit:coverage` → 35/35 pass, 100% coverage (confirms istanbul/load-nyc-config still works)
- `npm run lint` → clean (confirms eslintrc config loading still works)
- `npm audit` → **20 findings → 1** (only the unfixable undici bundled inside the `npm` package remains)

All dev/transitive — nothing here ships in the published package.

https://claude.ai/code/session_01Wr59bM31ZbRVQpSia8mCC7